### PR TITLE
Adicionado ícone do slack e ajustado palavra no texto da descrição 

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,13 +19,14 @@
         <a href="https://www.kaggle.com/joinville-ml">K</a>
         <a href="https://github.com/joinville-ml"><i class="fa fa-github" aria-hidden="true"></i></a>
         <a href="https://www.facebook.com/MachineLearningJoinville"><i class="fa fa-facebook-official" aria-hidden="true"></i></a>
+        <a href="https://joinville-ml-invite.herokuapp.com" target="_blank"><i class="fa fa-slack" aria-hidden="true"></i></a>
       </h2>
     </section>
 
     <section class="main-content">
       <h2><a id="comunidade" class="anchor" href="#comunidade" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Comunidade</h2>
 
-      <p>Este é o site da comunidade Joinville Machine Learning. Nossa comunidade nasceu depois que algumas pessoas se encontraram na Semana da Computação da UDESC. Realizamos um encontro mensal para apresentar os projetos em que estamos trabalhando, artigos interessantes e tutoriais de ferramentas. Somos entusiastas, cientistas e engenheiros que estão atuando da área, estudando ou tentando descobrir um pouco mais sobre o assunto. <em>Não existe nenhum pré-requisito para participar dos nossos eventos</em>.</p>
+      <p>Este é o site da comunidade Joinville Machine Learning. Nossa comunidade nasceu depois que algumas pessoas se encontraram na Semana da Computação da UDESC. Realizamos um encontro mensal para apresentar os projetos em que estamos trabalhando, artigos interessantes e tutoriais de ferramentas. Somos entusiastas, cientistas e engenheiros que estão atuando na área, estudando ou tentando descobrir um pouco mais sobre o assunto. <em>Não existe nenhum pré-requisito para participar dos nossos eventos</em>.</p>
 
       <p>Participe do nosso <a href="https://www.meetup.com/pt-BR/Joinville-Machine-Learning/">Meetup</a> e acompanhe os projetos da comunidade no nosso <a href="https://github.com/joinville-ml">GitHub</a> e <a href="https://www.kaggle.com/joinville-ml">Kaggle</a>.</p>
 


### PR DESCRIPTION
**O que foi efetuado:**

- Adicionado o ícone do slack com o link da página de receber convite;
- Ajustado o texto da descrição.

**PS.:** Link para receber o convite: https://joinville-ml-invite.herokuapp.com

**Links (referência/print):**

![screen shot 2016-11-18 at 12 33 14 am](https://cloud.githubusercontent.com/assets/6767689/20416542/a959c8b4-ad26-11e6-823c-f474462f451b.png)

@alfakini 